### PR TITLE
configurable api host

### DIFF
--- a/src/langtrace_python_sdk/constants/exporter/langtrace_exporter.py
+++ b/src/langtrace_python_sdk/constants/exporter/langtrace_exporter.py
@@ -1,1 +1,1 @@
-LANGTRACE_REMOTE_URL = "https://langtrace.ai/api/trace"
+LANGTRACE_REMOTE_URL = "https://langtrace.ai"

--- a/src/langtrace_python_sdk/extensions/langtrace_exporter.py
+++ b/src/langtrace_python_sdk/extensions/langtrace_exporter.py
@@ -2,12 +2,11 @@ import json
 import os
 import typing
 
-from langtrace_python_sdk.constants.exporter.langtrace_exporter import (
-    LANGTRACE_REMOTE_URL,
-)
 import requests
 from opentelemetry.sdk.trace.export import ReadableSpan, SpanExporter, SpanExportResult
 from opentelemetry.trace.span import format_trace_id
+
+from langtrace_python_sdk.constants.exporter.langtrace_exporter import LANGTRACE_REMOTE_URL
 
 
 class LangTraceExporter(SpanExporter):
@@ -49,9 +48,10 @@ class LangTraceExporter(SpanExporter):
     api_key: str
     write_to_remote_url: bool
 
-    def __init__(self, api_key: str = None, write_to_remote_url: bool = False) -> None:
-        self.api_key = api_key if api_key else os.environ.get("LANGTRACE_API_KEY")
+    def __init__(self, api_key: str = None, write_to_remote_url: bool = False, api_host: str | None = None) -> None:
+        self.api_key = api_key or os.environ.get("LANGTRACE_API_KEY")
         self.write_to_remote_url = write_to_remote_url
+        self.api_host: str = api_host or LANGTRACE_REMOTE_URL
 
         if self.write_to_remote_url and not self.api_key:
             raise ValueError("No API key provided")
@@ -66,7 +66,6 @@ class LangTraceExporter(SpanExporter):
         Returns:
             The result of the export SUCCESS or FAILURE
         """
-
         data = [
             {
                 "traceId": format_trace_id(span.get_span_context().trace_id),
@@ -86,7 +85,7 @@ class LangTraceExporter(SpanExporter):
         # Send data to remote URL
         try:
             requests.post(
-                url=LANGTRACE_REMOTE_URL,
+                url=f"{self.api_host}/api/trace",
                 data=json.dumps(data),
                 headers={"Content-Type": "application/json", "x-api-key": self.api_key},
             )

--- a/src/langtrace_python_sdk/extensions/langtrace_exporter.py
+++ b/src/langtrace_python_sdk/extensions/langtrace_exporter.py
@@ -48,7 +48,7 @@ class LangTraceExporter(SpanExporter):
     api_key: str
     write_to_remote_url: bool
 
-    def __init__(self, api_key: str = None, write_to_remote_url: bool = False, api_host: str | None = None) -> None:
+    def __init__(self, api_key: str = None, write_to_remote_url: bool = False, api_host: typing.Optional[str] = None) -> None:
         self.api_key = api_key or os.environ.get("LANGTRACE_API_KEY")
         self.write_to_remote_url = write_to_remote_url
         self.api_host: str = api_host or LANGTRACE_REMOTE_URL

--- a/src/langtrace_python_sdk/langtrace.py
+++ b/src/langtrace_python_sdk/langtrace.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -39,7 +40,7 @@ def init(
     write_to_langtrace_cloud: bool = True,
     debug_log_to_console: bool = False,
     custom_remote_exporter=None,
-    api_host: str | None = None,
+    api_host: Optional[str] = None,
 ):
     provider = TracerProvider()
 

--- a/src/langtrace_python_sdk/langtrace.py
+++ b/src/langtrace_python_sdk/langtrace.py
@@ -1,4 +1,3 @@
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -40,12 +39,12 @@ def init(
     write_to_langtrace_cloud: bool = True,
     debug_log_to_console: bool = False,
     custom_remote_exporter=None,
+    api_host: str | None = None,
 ):
-
     provider = TracerProvider()
 
     remote_write_exporter = (
-        LangTraceExporter(api_key, write_to_langtrace_cloud)
+        LangTraceExporter(api_key, write_to_langtrace_cloud, api_host=api_host)
         if custom_remote_exporter is None
         else custom_remote_exporter
     )


### PR DESCRIPTION
Allows for something like

langtrace.init(api_key=API_KEY, api_host="http://localhost:3000")

