### PR TITLE
add notice for self hosted setups

### DIFF
--- a/src/langtrace_python_sdk/extensions/langtrace_exporter.py
+++ b/src/langtrace_python_sdk/extensions/langtrace_exporter.py
@@ -119,7 +119,10 @@ class LangTraceExporter(SpanExporter):
         except RequestException as err:
             if not self.disable_logging:
                 print(Fore.RED + "Failed to export spans.")
-                print(Fore.RED + f"Error: {err}" + Fore.RESET)
+                print(Fore.RED + f"Error: {err}\r\n" + Fore.RESET)
+                if "invalid api key" in str(err).lower():
+                    print(Fore.YELLOW + "If you're self-hosting Langtrace, make sure to do one of the following to configure your trace endpoint (e.g., http://localhost:3000/api/trace):" + Fore.YELLOW)
+                    print(Fore.YELLOW + "1. Set the `LANGTRACE_API_HOST` environment variable, or\r\n2. Pass the `api_host` parameter to the `langtrace.init()` method.\r\n" + Fore.YELLOW)
             return SpanExportResult.FAILURE
 
     def shutdown(self) -> None:


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue to help is review the PR better and faster.

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/langtrace_python_sdk/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.py](../src/langtrace_python_sdk/constants/instrumentation/common.py)
- [ ] Created a folder under [instrumentation](../src/langtrace_python_sdk/instrumentation/) with the name of the integration with atleast `patch.py` and `instrumentation.py` files.
- [ ] Added instrumentation in `all_instrumentations` in [langtrace.py](../src/langtrace_python_sdk/langtrace.py) and to the `InstrumentationType` in [types.py](../src/langtrace_python_sdk/types/__init__.py) files.
- [ ] Added examples for the new integration in the [examples](../src/langtrace_python_sdk/examples/) folder.
- [ ] Updated [pyproject.toml](../pyproject.toml) to install new dependencies
- [ ] Updated the [README.md](../README.md) of [langtrace-python-sdk](https://github.com/Scale3-Labs/langtrace-python-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
