### PR TITLE
feat: adding otel host and header env var support

### DIFF
--- a/src/langtrace_python_sdk/extensions/langtrace_exporter.py
+++ b/src/langtrace_python_sdk/extensions/langtrace_exporter.py
@@ -76,7 +76,29 @@ class LangTraceExporter(SpanExporter):
         Returns:
             The result of the export SUCCESS or FAILURE
         """
-        if not self.api_key and not self.disable_logging:
+        headers = {
+            "Content-Type": "application/json",
+            "x-api-key": self.api_key,
+            "User-Agent": "LangtraceExporter",
+        }
+
+        # Check if the OTEL_EXPORTER_OTLP_HEADERS environment variable is set
+        otel_headers = os.getenv("OTEL_EXPORTER_OTLP_HEADERS", None)
+        if otel_headers:
+            # Parse and add to headers
+            for header in otel_headers.split(","):
+                key, value = header.split("=")
+                headers[key.strip()] = value.strip()
+
+        # Check if the OTEL_EXPORTER_OTLP_TRACES_HEADERS environment variable is set
+        otel_traces_headers = os.getenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", None)
+        if otel_traces_headers:
+            # Parse and add to headers
+            for header in otel_traces_headers.split(","):
+                key, value = header.split("=")
+                headers[key.strip()] = value.strip()
+
+        if not headers["x-api-key"] and not self.disable_logging:
             print(Fore.RED)
             print(
                 "Missing Langtrace API key, proceed to https://langtrace.ai to create one"
@@ -101,11 +123,7 @@ class LangTraceExporter(SpanExporter):
             response = requests.post(
                 url=f"{self.api_host}",
                 data=json.dumps(data),
-                headers={
-                    "Content-Type": "application/json",
-                    "x-api-key": self.api_key,
-                    "User-Agent": "LangtraceExporter",
-                },
+                headers=headers,
                 timeout=20,
             )
 
@@ -113,7 +131,9 @@ class LangTraceExporter(SpanExporter):
                 raise RequestException(response.text)
             if not self.disable_logging:
                 print(
-                    Fore.GREEN + f"Exported {len(spans)} spans successfully." + Fore.RESET
+                    Fore.GREEN
+                    + f"Exported {len(spans)} spans successfully."
+                    + Fore.RESET
                 )
             return SpanExportResult.SUCCESS
         except RequestException as err:
@@ -121,9 +141,21 @@ class LangTraceExporter(SpanExporter):
                 print(Fore.RED + "Failed to export spans.")
                 print(Fore.RED + f"Error: {err}\r\n" + Fore.RESET)
                 if "invalid api key" in str(err).lower():
-                    print(Fore.YELLOW + "If you're self-hosting Langtrace, make sure to do one of the following to configure your trace endpoint (e.g., http://localhost:3000/api/trace):" + Fore.YELLOW)
-                    print(Fore.YELLOW + "1. Set the `LANGTRACE_API_HOST` environment variable, or\r\n2. Pass the `api_host` parameter to the `langtrace.init()` method.\r\n" + Fore.YELLOW)
+                    print(
+                        Fore.YELLOW
+                        + "If you're self-hosting Langtrace, make sure to do one of the following to configure your trace endpoint (e.g., http://localhost:3000/api/trace):"
+                        + Fore.YELLOW
+                    )
+                    print(
+                        Fore.YELLOW
+                        + "1. Set the `LANGTRACE_API_HOST` environment variable, or\r\n2. Pass the `api_host` parameter to the `langtrace.init()` method.\r\n"
+                        + Fore.YELLOW
+                    )
             return SpanExportResult.FAILURE
 
     def shutdown(self) -> None:
-        print(Fore.WHITE + "⭐ Leave our github a star to stay on top of our updates - https://github.com/Scale3-Labs/langtrace" + Fore.RESET)
+        print(
+            Fore.WHITE
+            + "⭐ Leave our github a star to stay on top of our updates - https://github.com/Scale3-Labs/langtrace"
+            + Fore.RESET
+        )

--- a/src/langtrace_python_sdk/langtrace.py
+++ b/src/langtrace_python_sdk/langtrace.py
@@ -80,11 +80,19 @@ def init(
         sys.stdout = open(os.devnull, "w")
 
     host = (
-        os.environ.get("LANGTRACE_API_HOST", None) or api_host or LANGTRACE_REMOTE_URL
+        os.environ.get("LANGTRACE_API_HOST", None)
+        or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", None)
+        or os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None)
+        or api_host
+        or LANGTRACE_REMOTE_URL
     )
     check_if_sdk_is_outdated()
     print(Fore.GREEN + "Initializing Langtrace SDK.." + Fore.RESET)
-    print(Fore.WHITE + "⭐ Leave our github a star to stay on top of our updates - https://github.com/Scale3-Labs/langtrace" + Fore.RESET)
+    print(
+        Fore.WHITE
+        + "⭐ Leave our github a star to stay on top of our updates - https://github.com/Scale3-Labs/langtrace"
+        + Fore.RESET
+    )
     sampler = LangtraceSampler(disabled_methods=disable_tracing_for_functions)
     resource = Resource.create(
         attributes={

--- a/src/langtrace_python_sdk/langtrace.py
+++ b/src/langtrace_python_sdk/langtrace.py
@@ -81,8 +81,8 @@ def init(
 
     host = (
         os.environ.get("LANGTRACE_API_HOST", None)
-        or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", None)
         or os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None)
+        or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", None)
         or api_host
         or LANGTRACE_REMOTE_URL
     )


### PR DESCRIPTION
# Description

Adding OTEL env var support for following:
## For host
- OTEL_EXPORTER_OTLP_ENDPOINT
- OTEL_EXPORTER_OTLP_TRACES_ENDPOINT

`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if both are set

### The final order is
- env LANGTRACE_API_HOST
- env OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
- env OTEL_EXPORTER_OTLP_ENDPOINT
- `api_host` arg passed during Langtrace init
- if nothing found it's set to Langtrace cloud


## For Headers
- OTEL_EXPORTER_OTLP_HEADERS
- OTEL_EXPORTER_OTLP_TRACES_HEADERS

`OTEL_EXPORTER_OTLP_TRACES_HEADERS` takes precedence over `OTEL_EXPORTER_OTLP_HEADERS`
if both are set, the header keys' values in `OTEL_EXPORTER_OTLP_HEADERS` may be overridden by `OTEL_EXPORTER_OTLP_TRACES_HEADERS` 

--- 

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/langtrace_python_sdk/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.py](../src/langtrace_python_sdk/constants/instrumentation/common.py)
- [ ] Created a folder under [instrumentation](../src/langtrace_python_sdk/instrumentation/) with the name of the integration with atleast `patch.py` and `instrumentation.py` files.
- [ ] Added instrumentation in `all_instrumentations` in [langtrace.py](../src/langtrace_python_sdk/langtrace.py) and to the `InstrumentationType` in [types.py](../src/langtrace_python_sdk/types/__init__.py) files.
- [ ] Added examples for the new integration in the [examples](../src/langtrace_python_sdk/examples/) folder.
- [ ] Updated [pyproject.toml](../pyproject.toml) to install new dependencies
- [ ] Updated the [README.md](../README.md) of [langtrace-python-sdk](https://github.com/Scale3-Labs/langtrace-python-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
