### PR TITLE
Update api error notification for self hosted setups

### DIFF
--- a/src/langtrace_python_sdk/extensions/langtrace_exporter.py
+++ b/src/langtrace_python_sdk/extensions/langtrace_exporter.py
@@ -140,7 +140,10 @@ class LangTraceExporter(SpanExporter):
             if not self.disable_logging:
                 print(Fore.RED + "Failed to export spans.")
                 print(Fore.RED + f"Error: {err}\r\n" + Fore.RESET)
-                if "invalid api key" in str(err).lower():
+                if (
+                    "invalid api key" in str(err).lower()
+                    and self.api_host == f"{LANGTRACE_REMOTE_URL}/api/trace"
+                ):
                     print(
                         Fore.YELLOW
                         + "If you're self-hosting Langtrace, make sure to do one of the following to configure your trace endpoint (e.g., http://localhost:3000/api/trace):"


### PR DESCRIPTION
# Description

Only show notification if api_host is not set i.e. if api_host is set to the default.
