### PR TITLE
Add sentry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ langtrace.init(custom_remote_exporter=<your_exporter>, batch=<True or False>)
 | `api_host`                 | `Optional[str]`                     | `https://langtrace.ai/`       | The API host for the remote exporter.                                                                                             |
 | `disable_instrumentations` | `Optional[DisableInstrumentations]` | `None`                        | You can pass an object to disable instrumentation for specific vendors ex: `{'only': ['openai']}` or `{'all_except': ['openai']}` |
 
+### Error Reporting to Langtrace
+
+By default all sdk errors are reported to langtrace via Sentry. This can be disabled by setting the following enviroment variable to `False` like so `LANGTRACE_ERROR_REPORTING=False`
+
 ### Additional Customization
 
 - `@with_langtrace_root_span` - this decorator is designed to organize and relate different spans, in a hierarchical manner. When you're performing multiple operations that you want to monitor together as a unit, this function helps by establishing a "parent" (`LangtraceRootSpan` or whatever is passed to `name`) span. Then, any calls to the LLM APIs made within the given function (fn) will be considered "children" of this parent span. This setup is especially useful for tracking the performance or behavior of a group of operations collectively, rather than individually.
@@ -229,6 +233,7 @@ prompt = get_prompt_from_registry(<Registry ID>, options={"prompt_version": 1, "
 ```
 
 ### Opt out of tracing prompt and completion data
+
 By default, prompt and completion data are captured. If you would like to opt out of it, set the following env var,
 
 `TRACE_PROMPT_COMPLETION_DATA=false`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   'sqlalchemy',
   'fsspec>=2024.6.0',
   "transformers>=4.11.3",
+  "sentry-sdk>=2.14.0",
 ]
 
 requires-python = ">=3.9"

--- a/src/langtrace_python_sdk/constants/__init__.py
+++ b/src/langtrace_python_sdk/constants/__init__.py
@@ -1,1 +1,2 @@
 LANGTRACE_SDK_NAME = "langtrace-python-sdk"
+SENTRY_DSN = "https://7f8eed3a1237fb2efef0f5e96ab407af@o1419498.ingest.us.sentry.io/4507929133056000"

--- a/src/langtrace_python_sdk/langtrace.py
+++ b/src/langtrace_python_sdk/langtrace.py
@@ -166,10 +166,7 @@ def init(
         provider.add_span_processor(batch_processor_remote)
 
     sys.stdout = sys.__stdout__
-    if (
-        os.environ.get("LANGTRACE_ERROR_REPORTING", "True") == "True"
-        or os.environ.get("LANGTRACE_ERROR_REPORTING", "True") == "true"
-    ):
+    if os.environ.get("LANGTRACE_ERROR_REPORTING", "True") == "True":
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             traces_sample_rate=1.0,

--- a/src/langtrace_python_sdk/langtrace.py
+++ b/src/langtrace_python_sdk/langtrace.py
@@ -19,6 +19,7 @@ import sys
 from typing import Optional
 import importlib.util
 from colorama import Fore
+from langtrace_python_sdk.constants import LANGTRACE_SDK_NAME, SENTRY_DSN
 from opentelemetry import trace
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
@@ -60,8 +61,9 @@ from langtrace_python_sdk.types import (
     InstrumentationMethods,
     InstrumentationType,
 )
-from langtrace_python_sdk.utils import check_if_sdk_is_outdated
+from langtrace_python_sdk.utils import check_if_sdk_is_outdated, get_sdk_version
 from langtrace_python_sdk.utils.langtrace_sampler import LangtraceSampler
+import sentry_sdk
 
 
 def init(
@@ -164,6 +166,30 @@ def init(
         provider.add_span_processor(batch_processor_remote)
 
     sys.stdout = sys.__stdout__
+    if (
+        os.environ.get("LANGTRACE_ERROR_REPORTING", "True") == "True"
+        or os.environ.get("LANGTRACE_ERROR_REPORTING", "True") == "true"
+    ):
+        sentry_sdk.init(
+            dsn=SENTRY_DSN,
+            traces_sample_rate=1.0,
+            profiles_sample_rate=1.0,
+        )
+        sdk_options = {
+            "service_name": os.environ.get("OTEL_SERVICE_NAME")
+            or service_name
+            or sys.argv[0],
+            "disable_logging": disable_logging,
+            "disable_instrumentations": disable_instrumentations,
+            "disable_tracing_for_functions": disable_tracing_for_functions,
+            "batch": batch,
+            "write_spans_to_console": write_spans_to_console,
+            "custom_remote_exporter": custom_remote_exporter,
+            "sdk_name": LANGTRACE_SDK_NAME,
+            "sdk_version": get_sdk_version(),
+            "api_host": host,
+        }
+        sentry_sdk.set_context("sdk_init_options", sdk_options)
 
 
 def init_instrumentations(

--- a/src/langtrace_python_sdk/utils/__init__.py
+++ b/src/langtrace_python_sdk/utils/__init__.py
@@ -31,3 +31,7 @@ def set_event_prompt(span: Span, prompt):
 def check_if_sdk_is_outdated():
     SDKVersionChecker().check()
     return
+
+
+def get_sdk_version():
+    return SDKVersionChecker().get_sdk_version()

--- a/src/langtrace_python_sdk/utils/sdk_version_checker.py
+++ b/src/langtrace_python_sdk/utils/sdk_version_checker.py
@@ -44,6 +44,9 @@ class SDKVersionChecker:
             return self._current_version < latest_version
         return False
 
+    def get_sdk_version(self):
+        return self._current_version
+
     def check(self):
         if self.is_outdated():
             print(


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue to help is review the PR better and faster.

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/langtrace_python_sdk/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.py](../src/langtrace_python_sdk/constants/instrumentation/common.py)
- [ ] Created a folder under [instrumentation](../src/langtrace_python_sdk/instrumentation/) with the name of the integration with atleast `patch.py` and `instrumentation.py` files.
- [ ] Added instrumentation in `all_instrumentations` in [langtrace.py](../src/langtrace_python_sdk/langtrace.py) and to the `InstrumentationType` in [types.py](../src/langtrace_python_sdk/types/__init__.py) files.
- [ ] Added examples for the new integration in the [examples](../src/langtrace_python_sdk/examples/) folder.
- [ ] Updated [pyproject.toml](../pyproject.toml) to install new dependencies
- [ ] Updated the [README.md](../README.md) of [langtrace-python-sdk](https://github.com/Scale3-Labs/langtrace-python-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
