### PR TITLE
update dspy instrumentation and examples

### DIFF
--- a/src/examples/dspy_example/QA_basic.py
+++ b/src/examples/dspy_example/QA_basic.py
@@ -8,8 +8,8 @@ langtrace.init(disable_instrumentations={"all_except": ["dspy", "anthropic"]})
 
 # configure the language model to be used by dspy
 
-llm = dspy.Claude()
-dspy.settings.configure(lm=llm)
+lm = dspy.LM('claude-3-opus-20240229')
+dspy.configure(lm=lm)
 
 # create a prompt format that says that the llm will take a question and give back an answer
 predict = dspy.Predict("question -> answer")

--- a/src/examples/dspy_example/QA_basic_with_chain_of_thought.py
+++ b/src/examples/dspy_example/QA_basic_with_chain_of_thought.py
@@ -7,8 +7,8 @@ load_dotenv()
 langtrace.init(disable_instrumentations={"all_except": ["dspy", "anthropic"]})
 
 # configure the language model to be used by dspy
-llm = dspy.Claude()
-dspy.settings.configure(lm=llm)
+lm = dspy.LM('claude-3-opus-20240229')
+dspy.configure(lm=lm)
 
 
 # create a signature for basic question answering

--- a/src/examples/dspy_example/QA_basic_with_signature.py
+++ b/src/examples/dspy_example/QA_basic_with_signature.py
@@ -7,8 +7,8 @@ load_dotenv()
 langtrace.init(disable_instrumentations={"all_except": ["dspy", "anthropic"]})
 
 # configure the language model to be used by dspy
-llm = dspy.Claude()
-dspy.settings.configure(lm=llm)
+lm = dspy.LM('claude-3-opus-20240229')
+dspy.configure(lm=lm)
 
 
 # create a signature for basic question answering

--- a/src/examples/dspy_example/QA_multi_step_with_chain_of_thought.py
+++ b/src/examples/dspy_example/QA_multi_step_with_chain_of_thought.py
@@ -7,8 +7,8 @@ load_dotenv()
 langtrace.init(disable_instrumentations={"all_except": ["dspy", "anthropic"]})
 
 # configure the language model to be used by dspy
-llm = dspy.Claude()
-dspy.settings.configure(lm=llm)
+lm = dspy.LM('claude-3-opus-20240229')
+dspy.configure(lm=lm)
 
 
 # create a signature for basic question answering

--- a/src/examples/dspy_example/math_problems_cot.py
+++ b/src/examples/dspy_example/math_problems_cot.py
@@ -7,8 +7,8 @@ from langtrace_python_sdk import langtrace, with_langtrace_root_span
 
 langtrace.init()
 
-turbo = dspy.OpenAI(model="gpt-3.5-turbo", max_tokens=250)
-dspy.settings.configure(lm=turbo)
+lm = dspy.LM('gpt-3.5-turbo')
+dspy.configure(lm=lm)
 
 # Load math questions from the GSM8K dataset
 gsm8k = GSM8K()

--- a/src/examples/dspy_example/math_problems_cot_parallel.py
+++ b/src/examples/dspy_example/math_problems_cot_parallel.py
@@ -9,8 +9,8 @@ from langtrace_python_sdk import langtrace, with_langtrace_root_span, inject_add
 
 langtrace.init()
 
-turbo = dspy.OpenAI(model="gpt-3.5-turbo", max_tokens=250)
-dspy.settings.configure(lm=turbo)
+lm = dspy.LM('gpt-3.5-turbo')
+dspy.configure(lm=lm)
 
 # Load math questions from the GSM8K dataset
 gsm8k = GSM8K()

--- a/src/examples/dspy_example/program_of_thought_basic.py
+++ b/src/examples/dspy_example/program_of_thought_basic.py
@@ -5,8 +5,8 @@ from langtrace_python_sdk import langtrace, with_langtrace_root_span
 
 langtrace.init()
 
-turbo = dspy.OpenAI(model="gpt-3.5-turbo", max_tokens=250)
-dspy.settings.configure(lm=turbo)
+lm = dspy.LM('gpt-3.5-turbo')
+dspy.configure(lm=lm)
 
 
 # Define a simple signature for basic question answering

--- a/src/examples/dspy_example/react.py
+++ b/src/examples/dspy_example/react.py
@@ -15,8 +15,8 @@ from langtrace_python_sdk import langtrace, with_langtrace_root_span
 
 langtrace.init()
 
-turbo = dspy.OpenAI(model="gpt-3.5-turbo", max_tokens=250)
-dspy.settings.configure(lm=turbo)
+lm = dspy.LM('gpt-3.5-turbo')
+dspy.configure(lm=lm)
 
 colbertv2_wiki17_abstracts = dspy.ColBERTv2(
     url="http://20.102.90.50:2017/wiki17_abstracts"

--- a/src/langtrace_python_sdk/instrumentation/dspy/instrumentation.py
+++ b/src/langtrace_python_sdk/instrumentation/dspy/instrumentation.py
@@ -71,11 +71,6 @@ class DspyInstrumentation(BaseInstrumentor):
             patch_signature("MultiChainComparison.forward", version, tracer),
         )
         _W(
-            "dspy.predict.retry",
-            "Retry.forward",
-            patch_signature("Retry.forward", version, tracer),
-        )
-        _W(
             "dspy.evaluate.evaluate",
             "Evaluate.__call__",
             patch_evaluate("Evaluate", version, tracer),

--- a/src/langtrace_python_sdk/instrumentation/dspy/patch.py
+++ b/src/langtrace_python_sdk/instrumentation/dspy/patch.py
@@ -38,7 +38,7 @@ def patch_bootstrapfewshot_optimizer(operation_name, version, tracer):
                 prog = {
                     "name": args[0].prog.__class__.__name__,
                     "signature": (
-                        str(args[0].prog.signature) if args[0].prog.signature else None
+                        str(args[0].prog.signature) if hasattr(args[0].prog, "signature") else None
                     ),
                 }
                 span_attributes["dspy.optimizer.module.prog"] = json.dumps(prog)


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue to help is review the PR better and faster.

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/langtrace_python_sdk/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.py](../src/langtrace_python_sdk/constants/instrumentation/common.py)
- [ ] Created a folder under [instrumentation](../src/langtrace_python_sdk/instrumentation/) with the name of the integration with atleast `patch.py` and `instrumentation.py` files.
- [ ] Added instrumentation in `all_instrumentations` in [langtrace.py](../src/langtrace_python_sdk/langtrace.py) and to the `InstrumentationType` in [types.py](../src/langtrace_python_sdk/types/__init__.py) files.
- [ ] Added examples for the new integration in the [examples](../src/langtrace_python_sdk/examples/) folder.
- [ ] Updated [pyproject.toml](../pyproject.toml) to install new dependencies
- [ ] Updated the [README.md](../README.md) of [langtrace-python-sdk](https://github.com/Scale3-Labs/langtrace-python-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
